### PR TITLE
fix(android): replace deprecated offer() with trySend() in BluetoothManager for Kotlin 2.x compatibility

### DIFF
--- a/android/src/main/kotlin/com/tyx/flutter_matter/BluetoothManager.kt
+++ b/android/src/main/kotlin/com/tyx/flutter_matter/BluetoothManager.kt
@@ -84,7 +84,7 @@ class BluetoothManager : BleCallback {
                 if (producerScope.channel.isClosedForSend) {
                   Log.w(TAG, "Bluetooth device was scanned, but channel is already closed")
                 } else {
-                  offer(device)
+                  producerScope.trySend(device)
                 }
               }
 


### PR DESCRIPTION
## Summary
- replace deprecated `offer()` with `trySend()` in `BluetoothManager`
- fix Kotlin 2.0.0+ compatibility issue
- avoid deprecation-related build errors on newer Kotlin versions