### PR TITLE
fix(ios): propagate attestation validation flag

### DIFF
--- a/ios/Classes/DeviceControlHandle.m
+++ b/ios/Classes/DeviceControlHandle.m
@@ -231,6 +231,11 @@ static dispatch_queue_t connectDeviceQueue = nil;
     }
 }
 
+- (BOOL)shouldSkipAttestationCertificateValidation {
+    FlutterDeviceController *controller = [controls objectForKey:_handle];
+    return [[controller controllerParams] skipAttestationCertificateValidation];
+}
+
 - (instancetype)initWithHandle:(NSString *)handle {
     self = [super init];
     if (self) {
@@ -279,6 +284,7 @@ static FlutterControllerParams * mapFlutterControllerParams(NSDictionary *jsonOb
     NSNumber *attemptNetworkScanWiFi = [jsonObject objectForKey:@"attemptNetworkScanWiFi"];
     NSNumber *attemptNetworkScanThread = [jsonObject objectForKey:@"attemptNetworkScanThread"];
     NSNumber *skipCommissioningComplete = [jsonObject objectForKey:@"skipCommissioningComplete"];
+    NSNumber *skipAttestationCertificateValidation = [jsonObject objectForKey:@"skipAttestationCertificateValidation"];
     NSString *countryCode = [jsonObject objectForKey:@"countryCode"];
     NSNumber *adminSubject = [jsonObject objectForKey:@"adminSubject"];
     NSNumber *regulatoryLocationType = [jsonObject objectForKey:@"regulatoryLocationType"];
@@ -295,6 +301,9 @@ static FlutterControllerParams * mapFlutterControllerParams(NSDictionary *jsonOb
     if ([skipCommissioningComplete isEqual:[NSNull null]]) {
         skipCommissioningComplete = @(0);
     }
+    if ([skipAttestationCertificateValidation isEqual:[NSNull null]]) {
+        skipAttestationCertificateValidation = @(0);
+    }
     if ([regulatoryLocationType isEqual:[NSNull null]]) {
         regulatoryLocationType = @(0);
     }
@@ -308,7 +317,7 @@ static FlutterControllerParams * mapFlutterControllerParams(NSDictionary *jsonOb
         caseFailsafeTimerSeconds = @(30);
     }
     
-    return [[FlutterControllerParams alloc] init:[fabricId intValue] udpListenPort:[udpListenPort intValue] controllerVendorId:[controllerVendorId intValue] failsafeTimerSeconds:[failsafeTimerSeconds intValue] caseFailsafeTimerSeconds:[caseFailsafeTimerSeconds intValue] attemptNetworkScanWiFi:[attemptNetworkScanWiFi intValue] != 0 attemptNetworkScanThread:[attemptNetworkScanThread intValue] != 0 skipCommissioningComplete:[skipCommissioningComplete intValue] != 0 countryCode:countryCode regulatoryLocationType:[regulatoryLocationType intValue] keypairDelegate:keypairDelegateHandle rootCertificate:rootCertificateData intermediateCertificate:intermediateCertificateData operationalCertificate:operationalCertificateData ipk:ipkData adminSubject:[adminSubject intValue] enableServerInteractions:[enableServerInteractions intValue] != 0 setupURL:nil nodeId:[nodeId intValue]];
+    return [[FlutterControllerParams alloc] init:[fabricId intValue] udpListenPort:[udpListenPort intValue] controllerVendorId:[controllerVendorId intValue] failsafeTimerSeconds:[failsafeTimerSeconds intValue] caseFailsafeTimerSeconds:[caseFailsafeTimerSeconds intValue] attemptNetworkScanWiFi:[attemptNetworkScanWiFi intValue] != 0 attemptNetworkScanThread:[attemptNetworkScanThread intValue] != 0 skipCommissioningComplete:[skipCommissioningComplete intValue] != 0 skipAttestationCertificateValidation:[skipAttestationCertificateValidation intValue] != 0 countryCode:countryCode regulatoryLocationType:[regulatoryLocationType intValue] keypairDelegate:keypairDelegateHandle rootCertificate:rootCertificateData intermediateCertificate:intermediateCertificateData operationalCertificate:operationalCertificateData ipk:ipkData adminSubject:[adminSubject intValue] enableServerInteractions:[enableServerInteractions intValue] != 0 setupURL:nil nodeId:[nodeId intValue]];
 }
 
 static ZGMTRDeviceControllerStartupParams *

--- a/ios/Classes/FlutterControllerParams.h
+++ b/ios/Classes/FlutterControllerParams.h
@@ -11,6 +11,7 @@
 @property (nonatomic, assign) BOOL attemptNetworkScanWiFi;
 @property (nonatomic, assign) BOOL attemptNetworkScanThread;
 @property (nonatomic, assign) BOOL skipCommissioningComplete;
+@property (nonatomic, assign) BOOL skipAttestationCertificateValidation;
 @property (nonatomic, strong) NSString *countryCode;
 @property (nonatomic, assign) NSInteger regulatoryLocationType;
 @property (nonatomic, strong) id keypairDelegate;  // 可以根据实际需要定义类型
@@ -31,6 +32,7 @@
            attemptNetworkScanWiFi:(BOOL)attemptNetworkScanWiFi
          attemptNetworkScanThread:(BOOL)attemptNetworkScanThread
            skipCommissioningComplete:(BOOL)skipCommissioningComplete
+  skipAttestationCertificateValidation:(BOOL)skipAttestationCertificateValidation
                         countryCode:(NSString *)countryCode
           regulatoryLocationType:(NSInteger)regulatoryLocationType
                      keypairDelegate:(id)keypairDelegate

--- a/ios/Classes/FlutterControllerParams.m
+++ b/ios/Classes/FlutterControllerParams.m
@@ -11,6 +11,7 @@
        attemptNetworkScanWiFi:(BOOL)attemptNetworkScanWiFi
      attemptNetworkScanThread:(BOOL)attemptNetworkScanThread
     skipCommissioningComplete:(BOOL)skipCommissioningComplete
+skipAttestationCertificateValidation:(BOOL)skipAttestationCertificateValidation
                   countryCode:(NSString *)countryCode
        regulatoryLocationType:(NSInteger)regulatoryLocationType
               keypairDelegate:(id)keypairDelegate
@@ -34,6 +35,7 @@
         _attemptNetworkScanWiFi = attemptNetworkScanWiFi;
         _attemptNetworkScanThread = attemptNetworkScanThread;
         _skipCommissioningComplete = skipCommissioningComplete;
+        _skipAttestationCertificateValidation = skipAttestationCertificateValidation;
         _regulatoryLocationType = regulatoryLocationType;
         _adminSubject = adminSubject;
         _enableServerInteractions = enableServerInteractions;

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -457,7 +457,7 @@ class ControllerParams extends TransportObject {
   final bool attemptNetworkScanWiFi;
   final bool attemptNetworkScanThread;
   final bool skipCommissioningComplete;
-  // final bool skipAttestationCertificateValidation;
+  final bool skipAttestationCertificateValidation;
   final String countryCode;
   final int regulatoryLocationType;
   final KeypairDelegate? keypairDelegate;
@@ -479,7 +479,7 @@ class ControllerParams extends TransportObject {
     this.attemptNetworkScanWiFi = false,
     this.attemptNetworkScanThread = false,
     this.skipCommissioningComplete = false,
-    // this.skipAttestationCertificateValidation = false,
+    this.skipAttestationCertificateValidation = false,
     this.countryCode = "",
     this.regulatoryLocationType = 0,
     this.keypairDelegate,
@@ -507,7 +507,7 @@ class ControllerParams extends TransportObject {
     "attemptNetworkScanWiFi": attemptNetworkScanWiFi,
     "attemptNetworkScanThread": attemptNetworkScanThread,
     "skipCommissioningComplete": skipCommissioningComplete,
-    "skipAttestationCertificateValidation": true,
+    "skipAttestationCertificateValidation": skipAttestationCertificateValidation,
     "countryCode": countryCode,
     "regulatoryLocationType": regulatoryLocationType,
     "keypairDelegateHandle": keypairDelegate?.hashCode.toString(),


### PR DESCRIPTION
## Summary
- add `skipAttestationCertificateValidation` as an explicit `ControllerParams` field with a default value of `false`
- stop hardcoding attestation validation skipping in Dart so commissioning performs attestation validation by default
- map the flag through the iOS controller params path and read it from the controller when the NOC chain issuer reports whether validation should be skipped

## Testing
- not run (not requested)