### PR TITLE
fix(ios): correct return codes for continueCommissioning and openPairingWindowWithPIN

### DIFF
--- a/ios/Classes/DeviceControlHandle.m
+++ b/ios/Classes/DeviceControlHandle.m
@@ -588,7 +588,7 @@ static NSString *continueCommissioning(NSString *params) {
     id ignoreAttestationFailureValue = [jsonObject objectForKey:@"ignoreAttestationFailure"];
     NSError *error = nil;
     BOOL success = [deviceController continueCommissioningDevice:(void*)[devicePtr unsignedLongValue] ignoreAttestationFailure:[ignoreAttestationFailureValue isKindOfClass:[NSNumber class]] ? [ignoreAttestationFailureValue boolValue] : NO error:&error];
-    return createFlutterRequestResultWithCode(success ? 1 : 0, @{});
+    return createFlutterRequestResultWithCode(success ? 0 : 1, @{});
 }
 
 static NSString *createOperationalCertificate(NSString *params) {
@@ -1207,7 +1207,7 @@ static NSString * openPairingWindowWithPIN(NSString * params) {
         }
     }];
     
-    return createFlutterRequestResultWithCode(0, @{});
+    return createFlutterRequestResultWithCode(0, @{@"data": @(YES)});
 }
 
 static NSString * getFabricIndex(NSString * params) {


### PR DESCRIPTION
## Summary

- `continueCommissioning`: Fixed inverted success/failure code. The original `success ? 1 : 0`
  caused `code=1` to be returned on success, which the Dart `_requestPlatform` layer treats as
  an error. Corrected to `success ? 0 : 1`.
- `openPairingWindowWithPIN`: Added missing `data: true` field in the success response. The
  original `@{}` caused `result?['data'] == true` in Dart to always evaluate to `false`.

## Root Cause

Both issues stem from violations of the platform channel convention where `code=0` signals
success. `continueCommissioning` had the success/failure codes swapped, and
`openPairingWindowWithPIN` was missing the `data` boolean field that the Dart layer expects.

## Files Changed

- `ios/Classes/DeviceControlHandle.m` — two one-line fixes

## Test Plan

- [ ] `continueCommissioning` no longer throws in Dart on successful commissioning
- [ ] `openPairingWindowWithPIN()` returns `true` on success